### PR TITLE
devtools installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The dependency packages phyloseq and SPIEC-EASI (https://github.com/zdk123/Spiec
 The following code lines install both the dependencies and the gleesso package.
 
 ```r
+install.packages('devtools')
 library(devtools)
 
 source("https://bioconductor.org/biocLite.R")


### PR DESCRIPTION
@hjulienne 

I just added a line to the README file, usually 'devtools' is not installed by default, hence it is worth indicating it to install it.

Thanks!

Senthil